### PR TITLE
Vagrant setup for OF-Config Server

### DIFF
--- a/INSTALL.Vagrant.md
+++ b/INSTALL.Vagrant.md
@@ -1,0 +1,40 @@
+How to Install OF-CONFIG server using Vagrant
+=============================================
+
+This document describes how to build and install OF-CONFIG server and its dependencies using Vagrant
+The goal is to simplify the installation setup and get started with using OF-CONFIG server.
+
+Requirements
+============
+
+The guide assumes that Virtualbox and Vagrant are installed in your machine.
+You can download these software here:
+
+Virtualbox: https://www.virtualbox.org/wiki/Downloads
+Vagrant: http://www.vagrantup.com/downloads
+
+Installation
+============
+
+Start the VM Installation using:
+vagrant up (this will take few minutes)
+
+Once the installation is complete, SSH into the VM:
+vagrant ssh
+
+Run
+===
+Run the ofc-server using:
+ofc-server -v 3 -f
+
+Troubleshooting
+===============
+
+Note: the current VM is started with a private network address and hence
+cannot be reached via public network. If you prefer setting up the VM
+with public access, kindly update the Vagrantfile with
+`ofcserver.vm.network "public_network"` and choose your preferred
+network interface. For more information, refer to
+http://docs.vagrantup.com/v2/networking/public_network.html
+
+Note: The VM does not contain NETCONF Client such as Netopeer.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,65 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+$bootstrap_ubuntu = <<SCRIPT
+apt-get update
+apt-get install -y autoconf automake gcc libtool libxml2 libxml2-dev m4 make openssl libssl-dev pkg-config dbus dbus-*dev
+apt-get install -y linux-headers-$(uname -r) libxslt1-dev libssh2-1-dev libcurl4-openssl-dev xsltproc wget git
+apt-get clean && apt-get purge
+SCRIPT
+
+$install_ovs = <<SCRIPT
+cd /root/
+wget http://openvswitch.org/releases/openvswitch-2.3.1.tar.gz
+tar -xf openvswitch-2.3.1.tar.gz
+rm -f openvswitch-2.3.1.tar.gz
+cd openvswitch-2.3.1
+./configure --prefix=/ --datarootdir=/usr/share --with-linux=/lib/modules/$(uname -r)/build
+make && make install
+SCRIPT
+
+$start_ovs = <<SCRIPT
+/usr/share/openvswitch/scripts/ovs-ctl --system-id=random start
+SCRIPT
+
+$install_pyang = <<SCRIPT
+cd /root/
+wget https://pyang.googlecode.com/files/pyang-1.4.1.tar.gz
+tar -xf pyang-1.4.1.tar.gz
+rm -f pyang-1.4.1.tar.gz
+cd pyang-1.4.1
+python setup.py install
+SCRIPT
+
+$install_libnetconf = <<SCRIPT
+cd /root/
+git clone https://code.google.com/p/libnetconf
+cd libnetconf
+./configure && make
+make install
+SCRIPT
+
+$install_ofconfig = <<SCRIPT
+cd /root/
+git clone https://github.com/openvswitch/of-config.git
+cd of-config
+./boot.sh
+./configure --with-ovs-srcdir=/root/openvswitch-2.3.1 PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/
+make
+make install
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.define "ofcserver" do |ofcserver|
+     ofcserver.vm.box = "ubuntu/trusty64"
+     ofcserver.vm.provision :shell, inline: $bootstrap_ubuntu
+     ofcserver.vm.provision :shell, inline: $install_ovs
+     ofcserver.vm.provision :shell, inline: $start_ovs
+     ofcserver.vm.provision :shell, inline: $install_pyang
+     ofcserver.vm.provision :shell, inline: $install_libnetconf
+     ofcserver.vm.provision :shell, inline: $install_ofconfig
+  end
+end


### PR DESCRIPTION
This pull request adresses this issue https://github.com/openvswitch/of-config/issues/15

Added Vagrant setup for OF-Config Server
Added installation guide for vagrant setup

The docker installation is sort of complicated since we will have multiple processes in this setup and hence we can ignore it for now. 

Thanks,
Sriram
